### PR TITLE
Always use rework-vars to ensure default values get parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (opts, cb) {
 
   // even if variable were not provided
   // use rework-vars to process default values
-  css.use(vars(opts.vars))
+  css.use(vars(opts.variables))
 
   // utilize any custom rework plugins provided
   if (opts.plugins) {


### PR DESCRIPTION
Since rework now supports fallback values like `background: var(bg-color, #0f0);`, we need to always `use()` the `rework-vars` plugin.

I also changed the property name to `opts.vars` just for consistency and brevity. Cool?

This was made on top of the plugins PR, so that one should be merged first.
