### PR TITLE
update npm-less to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "mkdirp": "^0.5.0",
-    "npm-less": "^0.4.0",
+    "npm-less": "^0.5.0",
     "package-lookup": "^0.1.2",
     "resolve": "^0.6.1",
     "resrcify": "^1.0.1",


### PR DESCRIPTION
With this you can enable inline source maps in less :)

``` javascript
    css: {
      entry: "app/css/index.less",
      output: "dist/app.css",
      sourceMap: true
    }
```
