### PR TITLE
prevent crash when assets can't be copied

### DIFF
--- a/less.js
+++ b/less.js
@@ -8,6 +8,10 @@ var less = require('npm-less/less')
 
 var ctor = module.exports = function (opts, cb) {
   assetsConfig = opts.assets
+  if (assetsConfig) {
+    // Add default error handler
+    assetsConfig.onError = assetsConfig.onError || onError
+  }
 
   less(path.resolve(process.cwd(), opts.entry), {preprocess: preprocess}, function (err, output) {
     if (err) throw err
@@ -29,3 +33,8 @@ function preprocess (file, src) {
 
   return src
 }
+
+function onError(err) {
+  console.error('asset not copied:', err.path)
+}
+


### PR DESCRIPTION
Hi there, I'm using this patch to make things work in my bootstrap/less workflow.  I think it's a good thing not to crash by default in this case, but I'm not sure how you want to manage this.
