### PR TITLE
Do not autoprefix if bundling failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function atomifyCSS(opts, cb) {
       , _cb
 
     if (opts.transform && !err) src = opts.transform(src)
-    if (opts.autoprefixer) {
+    if (opts.autoprefixer && !err) {
       try {
         src = autoprefixer(typeof opts.autoprefixer === 'object'
           ? opts.autoprefixer


### PR DESCRIPTION
This obscures errors in bundling when auto prefix is enabled