### PR TITLE
Add ability to specify additional roots for LESS processor

### DIFF
--- a/less.js
+++ b/less.js
@@ -16,7 +16,7 @@ var ctor = module.exports = function (opts, cb) {
 
   if(opts.bower) less = bower
 
-  less(path.resolve(process.cwd(), opts.entry), {preprocess: preprocess}, function (err, output) {
+  less(path.resolve(process.cwd(), opts.entry), {preprocess: preprocess, paths: opts.paths}, function (err, output) {
     if (err) return process.nextTick(function () { cb(err) })
 
     process.nextTick(function() { cb(null, output.toCSS(opts)) })

--- a/test/fixtures/less/bundle-with-external-root.css
+++ b/test/fixtures/less/bundle-with-external-root.css
@@ -1,0 +1,6 @@
+.a {
+  color: #4d926f;
+}
+.external {
+  color: black;
+}

--- a/test/fixtures/less/external_root/external.less
+++ b/test/fixtures/less/external_root/external.less
@@ -1,0 +1,3 @@
+.external {
+  color: black;
+}

--- a/test/fixtures/less/needs-external-root.less
+++ b/test/fixtures/less/needs-external-root.less
@@ -1,0 +1,2 @@
+@import "./a";
+@import "external";

--- a/test/index.js
+++ b/test/index.js
@@ -408,4 +408,19 @@ function runTests () {
     })
   })
 
+  test('less works with multiple root paths', function (t) {
+    t.plan(2)
+
+    var cfg = {
+        entry: path.join(lessFixtures, 'needs-external-root.less'),
+        paths: [lessFixtures, path.join(lessFixtures, 'external_root')]
+      },
+      correct = fs.readFileSync(path.join(lessFixtures, 'bundle-with-external-root.css'), 'utf8')
+
+    css(cfg, function (err, src) {
+      t.error(err, 'does not error')
+      t.equal(src, correct)
+    })
+  })
+
 }


### PR DESCRIPTION
Currently, we can't specify additional roots for LESS resolving algorithm, even though less itself trivially supports it. This change tries to fix this.