### PR TITLE
Fix issues with global assigns to `less.Parser.importer` from both `bower-less` and `npm-less`

### DIFF
--- a/less.js
+++ b/less.js
@@ -1,6 +1,4 @@
-var less = require('npm-less/less')
-  , bower = require('bower-less/less')
-  , path = require('path')
+var path = require('path')
   , events = require('events')
   , resrc = require('resrcify/custom').resrc
   , regexp = /url\([\"\'](.*?)[\"\']\)/g
@@ -14,7 +12,11 @@ var ctor = module.exports = function (opts, cb) {
     assetsConfig.onError = assetsConfig.onError || onError
   }
 
-  if(opts.bower) less = bower
+  if(opts.bower) {
+    less = require('bower-less/less')
+  } else {
+    less = require('npm-less/less')
+  }
 
   less(path.resolve(process.cwd(), opts.entry), {preprocess: preprocess, paths: opts.paths}, function (err, output) {
     if (err) return process.nextTick(function () { cb(err) })


### PR DESCRIPTION
Both bower-less and npm-less assigns to `less.Parser.importer` to redefine importing logic as you can see here: [bower](https://github.com/cellvia/bower-less/blob/master/index.js), [npm](https://github.com/Raynos/npm-less/blob/master/index.js). So, when you `require` them both, you got messed environment. You will use npm-less parser, but bower-less importer. This PR tries to fix this issue. I don't know why it worked correctly earlier, but now I'm trying to migrate to node 5, and this thing blocks me from doing it.
